### PR TITLE
feat: add global search (Ctrl+K) and highlight matching text in results

### DIFF
--- a/app/catecismo-maior/page.tsx
+++ b/app/catecismo-maior/page.tsx
@@ -64,7 +64,7 @@ export default function LargerCatechismPage() {
 
           <div className="max-w-md mx-auto">
             <SearchBar
-              onSearch={setSearchQuery}
+              onSearch={(q) => { setSearchQuery(q); setCurrentPage(1); }}
               placeholder="Buscar no Catecismo Maior..."
               value={searchQuery}
             />
@@ -86,6 +86,7 @@ export default function LargerCatechismPage() {
                   references={question.scriptureReferences}
                   isCompleted={progress.largerCatechism.includes(question.id)}
                   onMarkAsRead={() => markLargerCatechismAsRead(question.id)}
+                  searchQuery={searchQuery}
                 />
               ))}
             </div>

--- a/app/catecismo-menor/page.tsx
+++ b/app/catecismo-menor/page.tsx
@@ -60,7 +60,7 @@ export default function ShorterCatechismPage() {
           
           <div className="max-w-md mx-auto">
             <SearchBar
-              onSearch={setSearchQuery}
+              onSearch={(q) => { setSearchQuery(q); setCurrentPage(1); }}
               placeholder="Buscar no Catecismo Menor..."
               value={searchQuery}
             />
@@ -80,6 +80,7 @@ export default function ShorterCatechismPage() {
                   references={question.scriptureReferences}
                   isCompleted={progress.shorterCatechism.includes(question.id)}
                   onMarkAsRead={() => markShorterCatechismAsRead(question.id)}
+                  searchQuery={searchQuery}
                 />
               ))}
             </div>

--- a/app/confissao/page.tsx
+++ b/app/confissao/page.tsx
@@ -69,7 +69,7 @@ export default function ConfessionPage() {
             
             <div className="max-w-md mx-auto">
               <SearchBar
-                onSearch={setSearchQuery}
+                onSearch={(q) => { setSearchQuery(q); setCurrentPage(1); }}
                 placeholder="Buscar na Confissão de Fé..."
                 value={searchQuery}
               />
@@ -97,6 +97,7 @@ export default function ConfessionPage() {
                             references={article.scriptureReferences}
                             isCompleted={progress.confessionSections.includes(`${chapter.id}-${article.id}`)}
                             onMarkAsRead={() => toggleConfessionSectionAsRead(chapter.id, article.id)}
+                            searchQuery={searchQuery}
                           />
                         );
                       })}

--- a/components/layout/Navbar.tsx
+++ b/components/layout/Navbar.tsx
@@ -5,6 +5,7 @@ import Link from 'next/link';
 import { Menu, X, Book, Search, Sun, Moon } from 'lucide-react';
 import { useTheme } from 'next-themes';
 import { Button } from '@/components/ui/button';
+import GlobalSearch from '@/components/search/GlobalSearch';
 
 const navigation = [
   { name: 'Início', href: '/' },
@@ -16,6 +17,7 @@ const navigation = [
 
 export default function Navbar() {
   const [isOpen, setIsOpen] = useState(false);
+  const [searchOpen, setSearchOpen] = useState(false);
   const [mounted, setMounted] = useState(false);
   const { theme, setTheme } = useTheme();
 
@@ -23,84 +25,123 @@ export default function Navbar() {
     setMounted(true);
   }, []);
 
+  useEffect(() => {
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') {
+        e.preventDefault();
+        setSearchOpen((prev) => !prev);
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, []);
+
   return (
-    <nav className="fixed top-0 w-full bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b border-border z-50">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex justify-between items-center h-16">
-          <div className="flex items-center">
-            <Link href="/" className="flex items-center space-x-2">
-              <Book className="h-8 w-8 text-amber-600" />
-              <span className="text-xl font-bold text-foreground">
-                Catechumenon
-              </span>
-            </Link>
-          </div>
-
-          {/* Desktop Navigation */}
-          <div className="hidden md:flex items-center space-x-8">
-            {navigation.map((item) => (
-              <Link
-                key={item.name}
-                href={item.href}
-                className="text-muted-foreground hover:text-foreground transition-colors text-sm font-medium"
-              >
-                {item.name}
+    <>
+      <nav className="fixed top-0 w-full bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b border-border z-50">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center h-16">
+            <div className="flex items-center">
+              <Link href="/" className="flex items-center space-x-2">
+                <Book className="h-8 w-8 text-amber-600" />
+                <span className="text-xl font-bold text-foreground">
+                  Catechumenon
+                </span>
               </Link>
-            ))}
-          </div>
+            </div>
 
-          <div className="flex items-center space-x-2">
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
-            >
-              {mounted ? (
-                theme === 'dark' ? (
-                  <Sun className="h-4 w-4" />
-                ) : (
-                  <Moon className="h-4 w-4" />
-                )
-              ) : (
-                <div className="h-4 w-4" />
-              )}
-            </Button>
+            {/* Desktop Navigation */}
+            <div className="hidden md:flex items-center space-x-8">
+              {navigation.map((item) => (
+                <Link
+                  key={item.name}
+                  href={item.href}
+                  className="text-muted-foreground hover:text-foreground transition-colors text-sm font-medium"
+                >
+                  {item.name}
+                </Link>
+              ))}
+            </div>
 
-            {/* Mobile menu button */}
-            <div className="md:hidden">
+            <div className="flex items-center space-x-2">
+              {/* Desktop search button */}
+              <Button
+                variant="outline"
+                size="sm"
+                className="hidden md:inline-flex items-center gap-2 text-muted-foreground"
+                onClick={() => setSearchOpen(true)}
+              >
+                <Search className="h-4 w-4" />
+                <span className="text-sm">Buscar...</span>
+                <kbd className="pointer-events-none ml-1 inline-flex h-5 select-none items-center gap-1 rounded border bg-muted px-1.5 font-mono text-[10px] font-medium text-muted-foreground">
+                  Ctrl K
+                </kbd>
+              </Button>
+
+              {/* Mobile search button */}
               <Button
                 variant="ghost"
                 size="sm"
-                onClick={() => setIsOpen(!isOpen)}
+                className="md:hidden"
+                onClick={() => setSearchOpen(true)}
               >
-                {isOpen ? (
-                  <X className="h-5 w-5" />
+                <Search className="h-4 w-4" />
+              </Button>
+
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}
+              >
+                {mounted ? (
+                  theme === 'dark' ? (
+                    <Sun className="h-4 w-4" />
+                  ) : (
+                    <Moon className="h-4 w-4" />
+                  )
                 ) : (
-                  <Menu className="h-5 w-5" />
+                  <div className="h-4 w-4" />
                 )}
               </Button>
+
+              {/* Mobile menu button */}
+              <div className="md:hidden">
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => setIsOpen(!isOpen)}
+                >
+                  {isOpen ? (
+                    <X className="h-5 w-5" />
+                  ) : (
+                    <Menu className="h-5 w-5" />
+                  )}
+                </Button>
+              </div>
             </div>
           </div>
         </div>
-      </div>
 
-      {/* Mobile Navigation */}
-      {isOpen && (
-        <div className="md:hidden">
-          <div className="px-2 pt-2 pb-3 space-y-1 bg-background border-b border-border">
-            {navigation.map((item) => (
-              <Link
-                key={item.name}
-                href={item.href}
-                className="block px-3 py-2 text-base font-medium text-muted-foreground hover:text-foreground hover:bg-muted rounded-md transition-colors"
-                onClick={() => setIsOpen(false)}
-              >
-                {item.name}
-              </Link>
-            ))}
+        {/* Mobile Navigation */}
+        {isOpen && (
+          <div className="md:hidden">
+            <div className="px-2 pt-2 pb-3 space-y-1 bg-background border-b border-border">
+              {navigation.map((item) => (
+                <Link
+                  key={item.name}
+                  href={item.href}
+                  className="block px-3 py-2 text-base font-medium text-muted-foreground hover:text-foreground hover:bg-muted rounded-md transition-colors"
+                  onClick={() => setIsOpen(false)}
+                >
+                  {item.name}
+                </Link>
+              ))}
+            </div>
           </div>
-        </div>
-      )}
-    </nav>
+        )}
+      </nav>
+
+      <GlobalSearch open={searchOpen} onOpenChange={setSearchOpen} />
+    </>
   );
 }

--- a/components/search/GlobalSearch.tsx
+++ b/components/search/GlobalSearch.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+import { useState, useMemo, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { Book, HelpCircle, FileText } from 'lucide-react';
+import {
+  Command,
+  CommandInput,
+  CommandList,
+  CommandEmpty,
+  CommandGroup,
+  CommandItem,
+} from '@/components/ui/command';
+import { Dialog, DialogContent } from '@/components/ui/dialog';
+import confessionData from '@/data/confession.json';
+import largerCatechismData from '@/data/larger-catechism.json';
+import shorterCatechismData from '@/data/shorter-catechism.json';
+import { ConfessionChapter, CatechismQuestion } from '@/types';
+
+interface GlobalSearchProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+interface SearchResult {
+  id: string;
+  title: string;
+  subtitle: string;
+  href: string;
+}
+
+const MAX_RESULTS_PER_GROUP = 8;
+
+export default function GlobalSearch({ open, onOpenChange }: GlobalSearchProps) {
+  const [query, setQuery] = useState('');
+  const router = useRouter();
+
+  const confession = confessionData as ConfessionChapter[];
+  const largerCatechism = largerCatechismData as CatechismQuestion[];
+  const shorterCatechism = shorterCatechismData as CatechismQuestion[];
+
+  useEffect(() => {
+    if (!open) setQuery('');
+  }, [open]);
+
+  const results = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return { confession: [], larger: [], shorter: [] };
+
+    const confessionResults: SearchResult[] = [];
+    for (const chapter of confession) {
+      if (confessionResults.length >= MAX_RESULTS_PER_GROUP) break;
+      const titleMatch = chapter.title.toLowerCase().includes(q);
+      const matchingArticle = chapter.articles.find((a) =>
+        a.text.toLowerCase().includes(q)
+      );
+      if (titleMatch || matchingArticle) {
+        confessionResults.push({
+          id: `conf-${chapter.id}`,
+          title: `Capítulo ${chapter.id}: ${chapter.title}`,
+          subtitle: matchingArticle
+            ? matchingArticle.text.substring(0, 100) + '...'
+            : chapter.articles[0]?.text.substring(0, 100) + '...',
+          href: '/confissao',
+        });
+      }
+    }
+
+    const largerResults: SearchResult[] = [];
+    for (const item of largerCatechism) {
+      if (largerResults.length >= MAX_RESULTS_PER_GROUP) break;
+      const questionMatch = item.question.toLowerCase().includes(q);
+      const answerMatch = item.answer.toLowerCase().includes(q);
+      if (questionMatch || answerMatch) {
+        largerResults.push({
+          id: `lc-${item.id}`,
+          title: `Pergunta ${item.id}`,
+          subtitle: item.question.substring(0, 100) + (item.question.length > 100 ? '...' : ''),
+          href: '/catecismo-maior',
+        });
+      }
+    }
+
+    const shorterResults: SearchResult[] = [];
+    for (const item of shorterCatechism) {
+      if (shorterResults.length >= MAX_RESULTS_PER_GROUP) break;
+      const questionMatch = item.question.toLowerCase().includes(q);
+      const answerMatch = item.answer.toLowerCase().includes(q);
+      if (questionMatch || answerMatch) {
+        shorterResults.push({
+          id: `sc-${item.id}`,
+          title: `Pergunta ${item.id}`,
+          subtitle: item.question.substring(0, 100) + (item.question.length > 100 ? '...' : ''),
+          href: '/catecismo-menor',
+        });
+      }
+    }
+
+    return {
+      confession: confessionResults,
+      larger: largerResults,
+      shorter: shorterResults,
+    };
+  }, [query, confession, largerCatechism, shorterCatechism]);
+
+  const hasResults =
+    results.confession.length > 0 ||
+    results.larger.length > 0 ||
+    results.shorter.length > 0;
+
+  const handleSelect = (href: string) => {
+    onOpenChange(false);
+    router.push(href);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="overflow-hidden p-0 shadow-lg">
+        <Command
+          shouldFilter={false}
+          className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5"
+        >
+          <CommandInput
+            placeholder="Buscar em todos os documentos..."
+            value={query}
+            onValueChange={setQuery}
+          />
+          <CommandList>
+            {query.trim() && !hasResults && (
+              <CommandEmpty>Nenhum resultado encontrado.</CommandEmpty>
+            )}
+
+            {results.confession.length > 0 && (
+              <CommandGroup heading="Confissão de Fé">
+                {results.confession.map((item) => (
+                  <CommandItem
+                    key={item.id}
+                    value={item.id}
+                    onSelect={() => handleSelect(item.href)}
+                  >
+                    <Book className="mr-2 h-4 w-4 shrink-0 text-blue-500" />
+                    <div className="flex flex-col overflow-hidden">
+                      <span className="font-medium truncate">{item.title}</span>
+                      <span className="text-xs text-muted-foreground truncate">
+                        {item.subtitle}
+                      </span>
+                    </div>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+
+            {results.larger.length > 0 && (
+              <CommandGroup heading="Catecismo Maior">
+                {results.larger.map((item) => (
+                  <CommandItem
+                    key={item.id}
+                    value={item.id}
+                    onSelect={() => handleSelect(item.href)}
+                  >
+                    <HelpCircle className="mr-2 h-4 w-4 shrink-0 text-green-500" />
+                    <div className="flex flex-col overflow-hidden">
+                      <span className="font-medium truncate">{item.title}</span>
+                      <span className="text-xs text-muted-foreground truncate">
+                        {item.subtitle}
+                      </span>
+                    </div>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+
+            {results.shorter.length > 0 && (
+              <CommandGroup heading="Catecismo Menor">
+                {results.shorter.map((item) => (
+                  <CommandItem
+                    key={item.id}
+                    value={item.id}
+                    onSelect={() => handleSelect(item.href)}
+                  >
+                    <FileText className="mr-2 h-4 w-4 shrink-0 text-purple-500" />
+                    <div className="flex flex-col overflow-hidden">
+                      <span className="font-medium truncate">{item.title}</span>
+                      <span className="text-xs text-muted-foreground truncate">
+                        {item.subtitle}
+                      </span>
+                    </div>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+          </CommandList>
+        </Command>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/ui/ContentCard.tsx
+++ b/components/ui/ContentCard.tsx
@@ -6,12 +6,13 @@ import { Dialog, DialogContent, DialogTitle, DialogTrigger, DialogHeader, Dialog
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { getBibleApiUrl } from '@/lib/bibleUtils';
+import HighlightText from '@/components/ui/HighlightText';
 
 type BooksInput = string[] | string[][];
 interface Section {
   title: string;
-  books: BooksInput;        
-  columns?: number;     
+  books: BooksInput;
+  columns?: number;
 }
 
 interface ContentCardProps {
@@ -22,6 +23,7 @@ interface ContentCardProps {
   references?: string[];
   isCompleted?: boolean;
   onMarkAsRead?: (read: boolean) => void;
+  searchQuery?: string;
 }
 
 /** Normaliza books em colunas */
@@ -132,7 +134,8 @@ export default function ContentCard({
   subtitle,
   references,
   isCompleted = false,
-  onMarkAsRead
+  onMarkAsRead,
+  searchQuery = '',
 }: ContentCardProps) {
   const [open, setOpen] = useState(false);
   const [read, setRead] = useState(isCompleted);
@@ -153,7 +156,7 @@ export default function ContentCard({
     <>
       {content && (
         <p className="text-sm text-muted-foreground leading-relaxed mb-4 whitespace-pre-line">
-          {content}
+          <HighlightText text={content} query={searchQuery} />
         </p>
       )}
       {hasSections && sections!.map((s, i) => <SectionGrid key={i} section={s} />)}
@@ -184,10 +187,12 @@ export default function ContentCard({
             <div className="flex items-start justify-between">
               <div>
                 <CardTitle className="text-lg font-semibold text-foreground">
-                  {title}
+                  <HighlightText text={title} query={searchQuery} />
                 </CardTitle>
                 {subtitle && (
-                  <p className="text-sm text-muted-foreground mt-1">{subtitle}</p>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    <HighlightText text={subtitle} query={searchQuery} />
+                  </p>
                 )}
               </div>
               {read && (
@@ -214,7 +219,9 @@ export default function ContentCard({
         </DialogHeader>
 
         {subtitle && (
-          <p className="text-sm text-muted-foreground mt-1">{subtitle}</p>
+          <p className="text-sm text-muted-foreground mt-1">
+            <HighlightText text={subtitle} query={searchQuery} />
+          </p>
         )}
 
         <ScrollArea className="max-h-[70vh] pr-6">

--- a/components/ui/HighlightText.tsx
+++ b/components/ui/HighlightText.tsx
@@ -1,0 +1,36 @@
+import { escapeRegex } from '@/utils/searchUtils';
+
+interface HighlightTextProps {
+  text: string;
+  query: string;
+  className?: string;
+  highlightClassName?: string;
+}
+
+export default function HighlightText({
+  text,
+  query,
+  className,
+  highlightClassName = 'bg-amber-200 dark:bg-amber-700 rounded-sm px-0.5',
+}: HighlightTextProps) {
+  if (!query.trim()) {
+    return <span className={className}>{text}</span>;
+  }
+
+  const regex = new RegExp(`(${escapeRegex(query)})`, 'gi');
+  const parts = text.split(regex);
+
+  return (
+    <span className={className}>
+      {parts.map((part, i) =>
+        regex.test(part) ? (
+          <mark key={i} className={highlightClassName}>
+            {part}
+          </mark>
+        ) : (
+          part
+        )
+      )}
+    </span>
+  );
+}

--- a/utils/searchUtils.ts
+++ b/utils/searchUtils.ts
@@ -1,0 +1,3 @@
+export function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}


### PR DESCRIPTION
   Add a command palette for searching across all documents (Confissão,
   Catecismo Maior, Catecismo Menor) with grouped results and navigation.
   Highlight search terms in ContentCard titles, subtitles, and content.
   Reset pagination to page 1 when searching on individual pages.